### PR TITLE
chore(package): modify coverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "ava --timeout 10000",
     "test:coverage": "nyc npm test",
-    "coverage": "nyc report --reporter=lcov && codecov",
+    "coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "build": "NODE_ENV=production babel index.js --out-dir lib",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
According to https://github.com/bcoe/nyc/pull/233/files, we should pipe out the coverage report.