### PR TITLE
Drop raf dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-import raf from 'raf'
-
 const rafThrottle = callback => {
   let requestId
 
@@ -10,12 +8,12 @@ const rafThrottle = callback => {
 
   const throttled = (...args) => {
     if (requestId == null) {
-      requestId = raf(later(args))
+      requestId = requestAnimationFrame(later(args))
     }
   }
 
   throttled.cancel = () =>
-    raf.cancel(requestId)
+    cancelAnimationFrame(requestId)
 
   return throttled
 }

--- a/package.json
+++ b/package.json
@@ -32,11 +32,9 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.6.5",
     "codecov": "^1.0.1",
+    "raf": "^3.2.0",
     "nyc": "^10.0.0",
     "sinon": "^1.17.3"
-  },
-  "dependencies": {
-    "raf": "^3.2.0"
   },
   "ava": {
     "files": [

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@ import { spy } from 'sinon'
 import raf from 'raf'
 import throttle from './index.js'
 
+raf.polyfill();
+
 test.cb('throttle', t => {
   t.plan(1)
 


### PR DESCRIPTION
`requestAnimationFrame` is available on [92%-97% of browsers.](http://caniuse.com/#feat=requestanimationframe)

This PR drops the dependency. If IE9- support is required, they can load the polyfill 