### PR TITLE
refactor(rafThrottle): Fixed the comparison operator to ===

### DIFF
--- a/rafThrottle.js
+++ b/rafThrottle.js
@@ -7,7 +7,7 @@ const rafThrottle = callback => {
   }
 
   const throttled = (...args) => {
-    if (requestId === null) {
+    if ((requestId === null) || (requestId === undefined)) {
       requestId = requestAnimationFrame(later(args))
     }
   }

--- a/rafThrottle.js
+++ b/rafThrottle.js
@@ -7,7 +7,7 @@ const rafThrottle = callback => {
   }
 
   const throttled = (...args) => {
-    if (requestId == null) {
+    if (requestId === null) {
       requestId = requestAnimationFrame(later(args))
     }
   }


### PR DESCRIPTION
rafThrottle uses `==`, so updating that to `===`