### PR TITLE
Fixed cancel preventing further calls to requestAnimationFrame.

### DIFF
--- a/rafThrottle.js
+++ b/rafThrottle.js
@@ -12,8 +12,10 @@ const rafThrottle = callback => {
     }
   }
 
-  throttled.cancel = () =>
+  throttled.cancel = () => {
     cancelAnimationFrame(requestId)
+    requestId = null
+  }
 
   return throttled
 }

--- a/test.js
+++ b/test.js
@@ -86,3 +86,19 @@ test('cancel the trailing throttled invocation', done => {
     done()
   })
 })
+
+test('resume normal operation after canceling the trailing throttled invocation', done => {
+  expect.assertions(1)
+
+  const callbackSpy = jest.fn()
+
+  const throttled = throttle(callbackSpy)
+  throttled()
+  throttled.cancel()
+  throttled()
+
+  raf(() => {
+    expect(callbackSpy.mock.calls.length).toBe(1)
+    done()
+  })
+})


### PR DESCRIPTION
Hi,

I just noticed, that the throttled function stopped getting called, after cancelling a requested call, because requestId was not reset to null/undefined.

I added a test-case for this scenario and fixed it.

Kind regards,
Marc