### PR TITLE
proper testcase for preserving 1st context fails

### DIFF
--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ test('call the callback with arguments', done => {
   })
 })
 
-test('preserve the context of the first call', done => {
+test('preserves the context of the first call', done => {
   expect.assertions(1)
 
   const callbackSpy = jest.fn()
@@ -47,8 +47,13 @@ test('preserve the context of the first call', done => {
   c2.throttled()
 
   raf(() => {
-    expect(callbackSpy.mock.instances[0]).toBe(c1)
-    done()
+    const c3 = { throttled }
+    c3.throttled()
+
+    raf(() => {
+      expect(callbackSpy.mock.instances[1]).toBe(c1)
+      done()
+    })
   })
 })
 


### PR DESCRIPTION
If we make "preserves the context of the first call" testcase just slightly more complex, we clearly see it doesn't actually preserve the context of the 1st call as promised.
What it does is preserving the context of the 1st call **after the last animation frame**. When animation frames happen and how often is the last thing a developer wants to care about, so current behavior is close to unpredictable and thus unreliable.
I personally see 2 solutions to this problem:
1. Make no assumptions regarding context (like `lodash.throttle`). This is the smartest choice.
2. Treat context as an argument and invoke the callback with the most recent context (if we want those dances around context).