### PR TITLE
callback gets invoked with the most recent args

### DIFF
--- a/rafThrottle.js
+++ b/rafThrottle.js
@@ -1,14 +1,17 @@
 const rafThrottle = callback => {
   let requestId = null
 
-  const later = (context, args) => () => {
+  let lastArgs
+
+  const later = (context) => () => {
     requestId = null
-    callback.apply(context, args)
+    callback.apply(context, lastArgs)
   }
 
   const throttled = function(...args) {
+    lastArgs = args;
     if (requestId === null) {
-      requestId = requestAnimationFrame(later(this, args))
+      requestId = requestAnimationFrame(later(this))
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -52,6 +52,22 @@ test('preserve the context of the first call', done => {
   })
 })
 
+test('invokes the callback with the most recent args', done => {
+  expect.assertions(1)
+
+  const callbackSpy = jest.fn()
+
+  const throttled = throttle(callbackSpy)
+
+  throttled(1)
+  throttled(2)
+
+  raf(() => {
+    expect(callbackSpy).lastCalledWith(2);
+    done()
+  })
+})
+
 test('more throttles', done => {
   expect.assertions(1)
 


### PR DESCRIPTION
Reason:
If I use `raf-throttle` to throttle a function like `updatePosition`, I would expect that when the callback gets actually invoked, it would draw the most relevant position on the screen. What the library does for the moment is remembering the most outdated arguments which is obviously not what most developers expect.
Another source for the expected behavior is: https://lodash.com/docs/4.17.11#debounce