### PR TITLE
initializing requestId with null (adds consistency)

### DIFF
--- a/rafThrottle.js
+++ b/rafThrottle.js
@@ -1,5 +1,5 @@
 const rafThrottle = callback => {
-  let requestId
+  let requestId = null
 
   const later = (context, args) => () => {
     requestId = null
@@ -7,7 +7,7 @@ const rafThrottle = callback => {
   }
 
   const throttled = function(...args) {
-    if ((requestId === null) || (requestId === undefined)) {
+    if (requestId === null) {
       requestId = requestAnimationFrame(later(this, args))
     }
   }


### PR DESCRIPTION
Rather than adding checks for all possible value types, let's just be consistent with the initial value.